### PR TITLE
- revert back, to be krypton compatible

### DIFF
--- a/resources/lib/main_module.py
+++ b/resources/lib/main_module.py
@@ -288,7 +288,7 @@ class MainModule:
         result = dialog.result
         del dialog
         if result:
-            while getCondVisibility("System.HasActiveModalDialog | System.HasVisibleModalDialog"):
+            while getCondVisibility("System.HasModalDialog | System.HasVisibleModalDialog"):
                 xbmc.executebuiltin("Action(Back)")
                 xbmc.sleep(300)
             xbmc.executebuiltin(result.getfilename())


### PR DESCRIPTION
 -revert back, to be krypton compatible

System.HasModalDialog () = "just "result nop in leia
but 
System.HasVisibleModalDialog (true when modal dialog has finished the animation, which should be intended)
System.HasActiveModalDialog (true when control will be instantly visible on closing, i think not intended)

System.HasModalDialog | System.HasVisibleModalDialog" (the or = | ,should do the compatibility)

depending to #2
pr: 1234ffd2097841315593c29f042ab23fda106bf0